### PR TITLE
Fix - Many-to-many self-referencing relations bug

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -4282,8 +4282,10 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $lowerRelatedName = lcfirst($relatedName);
         $lowerSingleRelatedName = lcfirst($this->getFKPhpNameAffix($crossFK, $plural = false));
 
-        $middelFks = $refFK->getTable()->getForeignKeys();
-        $isFirstPk = ($middelFks[0]->getForeignTableCommonName() == $this->getTable()->getCommonName());
+        /** @var \ForeignKey $refFK */
+        /** @var \Column[] $middlePks */
+        $middlePks = $refFK->getTable()->getPrimaryKey();
+        $isFirstPk = ($middlePks[0]->getName() === $refFK->getLocalColumnName());
 
         $script .= "
             if (\$this->{$lowerRelatedName}ScheduledForDeletion !== null) {


### PR DESCRIPTION
Fix a way it determines first PK on self-referencing many-to-many relations

Previously, it was producing an invalid order in case we're using
a many-to-many cross-ref table referencing to the same table twice.
Thus checking for a table name is not enough.
Now we just check if the first PK is the same as the given FK. That's it.