### PR TITLE
Fix - PHP 7.3 compatibility

### DIFF
--- a/generator/lib/platform/PgsqlPlatform.php
+++ b/generator/lib/platform/PgsqlPlatform.php
@@ -393,7 +393,7 @@ ALTER TABLE %s ALTER COLUMN %s;
         foreach ($changedProperties as $key => $property) {
             switch ($key) {
                 case 'defaultValueType':
-                    continue;
+                    break;
                 case 'size':
                 case 'type':
                 case 'scale':


### PR DESCRIPTION
Fix warning on "continue targeting switch statement"

See https://www.php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch