### PR TITLE
Fix - Postgres 12 incompatibility

### DIFF
--- a/generator/lib/reverse/pgsql/PgsqlSchemaParser.php
+++ b/generator/lib/reverse/pgsql/PgsqlSchemaParser.php
@@ -175,7 +175,7 @@ class PgsqlSchemaParser extends BaseSchemaParser
                                         att.atttypmod,
                                         att.atthasdef,
                                         att.attnotnull,
-                                        def.adsrc,
+                                        pg_get_expr(def.adbin, def.adrelid) as adsrc,
                                         CASE WHEN att.attndims > 0 THEN 1 ELSE 0 END AS isarray,
                                         CASE
                                             WHEN ty.typname = 'bpchar'


### PR DESCRIPTION
Fixes #14

Drop using a deprecated & dropped `adsrc` column

See https://www.postgresql.org/docs/12/release-12.html

> This column has been deprecated for a long time, because it did not update in response to other catalog changes (such as column renamings). The recommended way to get a text version of a default-value expression from `pg_attrdef` is `pg_get_expr(adbin, adrelid)`.

